### PR TITLE
Changed `drawNew`'s `throws` to `rethrows`

### DIFF
--- a/Sources/DrawingTools/NativeImage Extensions.swift
+++ b/Sources/DrawingTools/NativeImage Extensions.swift
@@ -250,7 +250,7 @@ public extension NativeImage {
         size: CGSize,
         context: GraphicsContext = .current,
         artist: ArtistWithImage)
-        throws -> NativeImage
+        rethrows -> NativeImage
     {
         try NativeImage(size: size).inGraphicsContext(context, withFocus: true) { image, context in
             try artist(image, context)
@@ -279,7 +279,7 @@ public extension NativeImage {
         size: CGSize,
         context: GraphicsContext = .current,
         artist: Artist)
-        throws -> NativeImage
+        rethrows -> NativeImage
     {
         try drawNew(size: size, context: context) { _, context in
             try artist(context)

--- a/Tests/DrawingToolsTests/Swift_Drawing_ToolsTests.swift
+++ b/Tests/DrawingToolsTests/Swift_Drawing_ToolsTests.swift
@@ -59,8 +59,8 @@ final class Swift_Drawing_ToolsTests: XCTestCase {
 
 
 extension NativeImage {
-    static func swatch(color: NativeColor, size: CGSize = .one) throws -> NativeImage {
-        try drawNew(size: size, context: .goodForSwatch(size: size)) { context in
+    static func swatch(color: NativeColor, size: CGSize = .one) -> NativeImage {
+        drawNew(size: size, context: .goodForSwatch(size: size)) { context in
             guard let context = context else {
                 XCTFail("No context?")
                 return


### PR DESCRIPTION
This should be a 1.1.0 since this will generate a new warning for anything using this function which didn't throw an error in the artist body