### PR TITLE
2.0.0: Requiring RectangleTools 3.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/RougeWare/Swift-Rectangle-Tools.git",
         "state": {
           "branch": null,
-          "revision": "28d5ec88e786f65f3127c56049045c6b17fc3121",
-          "version": "2.9.0"
+          "revision": "094f0bbf7e84680633d0c535a5f987cd1c9f7258",
+          "version": "3.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -7,10 +7,10 @@ let package = Package(
     name: "Swift Drawing Tools",
     
     platforms: [
-        .iOS(.v11),
-        .macOS(.v10_12),
-        .watchOS(.v4),
-        .tvOS(.v11),
+        .iOS(.v13),
+        .macOS(.v10_15),
+        .watchOS(.v6),
+        .tvOS(.v13),
     ],
     
     products: [
@@ -21,10 +21,10 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/RougeWare/Swift-Rectangle-Tools.git", from: "2.9.0"),
-        .package(url: "https://github.com/RougeWare/Swift-Cross-Kit-Types.git", from: "1.0.0"),
-        .package(url: "https://github.com/RougeWare/Swift-Optional-Tools.git",  from: "1.0.0"),
-        .package(url: "https://github.com/koher/swift-image.git", from: "0.7.0"),
+        .package(name: "RectangleTools", url: "https://github.com/RougeWare/Swift-Rectangle-Tools.git", from: "3.0.0"),
+        .package(name: "CrossKitTypes", url: "https://github.com/RougeWare/Swift-Cross-Kit-Types.git", from: "1.0.0"),
+        .package(name: "OptionalTools", url: "https://github.com/RougeWare/Swift-Optional-Tools.git",  from: "1.0.0"),
+        .package(name: "SwiftImage", url: "https://github.com/koher/swift-image.git", from: "0.7.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Tests/DrawingToolsTests/Swift_Drawing_ToolsTests.swift
+++ b/Tests/DrawingToolsTests/Swift_Drawing_ToolsTests.swift
@@ -12,6 +12,7 @@ final class Swift_Drawing_ToolsTests: XCTestCase {
     let testColorForSwiftImage = RGB<UInt8>(red: 0x42,      green: 0x69,      blue: 0xAD)
     let size = CGSize(width: 2, height: 2)
     
+    
     func testDrawSwatch() throws {
         let nativeImage = NativeImage.swatch(color: testColor, size: size)
         
@@ -20,7 +21,7 @@ final class Swift_Drawing_ToolsTests: XCTestCase {
             return
         }
         
-        guard let pngImage = Image<RGB<UInt8>>(data: pngData) else {
+        guard let pngImage = PNG(data: pngData) else {
             XCTFail("PNG data not PNG data?")
             return
         }
@@ -60,10 +61,179 @@ final class Swift_Drawing_ToolsTests: XCTestCase {
     }
     
     
+    /// Draws a simple image and checks all the bits to make sure it looks like we expect
+    ///
+    /// ```
+    ///   0
+    /// 0 🟨🟨🟥🟨🟨
+    ///   🟨🟥⬜️🟩🟨
+    ///   ⬛️⬜️⬜️⬜️🟩
+    ///   🟨⬛️⬜️🟦🟨
+    ///   🟨🟨🟦🟨🟨
+    /// ```
+    func testDrawDiamond() {
+        
+        let intImageSize = IntSize(width: 5, height: 5)
+        let imageSize = CGSize(intImageSize)
+        
+        let white  = NativeColor.white.cgColor
+        let black  = NativeColor.black.cgColor
+        let red    = NativeColor.red.cgColor
+        let green  = NativeColor.green.cgColor
+        let blue   = NativeColor.blue.cgColor
+        let yellow = NativeColor.yellow.cgColor
+        
+        let nativeImage = NativeImage.drawNew(size: imageSize, context: .new(size: .init(intImageSize), opaque: true, scale: .oneToOne), flipped: true) { context in
+            guard let context = context else {
+                return XCTFail("No context when drawing")
+            }
+            
+            context.setShouldAntialias(false)
+            context.setLineWidth(1)
+            
+            context.setFillColor(white)
+            context.fill(.init(origin: .zero, size: imageSize))
+            
+            // Since CGContext always strokes paths from the center, we have to manually offset these lines so they
+            // appear a 0.5px offset from where we expect them.
+            // You can check this by drawing a custom view, or using purely native tools to draw this image instead of
+            // this package, then saving that image as a PNG.
+            // These CGContext setting lines are there to help mitigate this.
+            context.setLineJoin(CGLineJoin.miter)
+            context.setMiterLimit(.infinity)
+            
+            context.setStrokeColor(yellow)
+            context.stroke(.init(x: 0.5, y: 0.5, width: 4, height: 4))
+
+            context.setStrokeColor(red)
+            context.move   (to: .init(x: 1.5, y: 1.5))
+            context.addLine(to: .init(x: 2.5, y: 0.5))
+            context.strokePath()
+
+            context.setStrokeColor(green)
+            context.move   (to: .init(x: 3.5, y: 1.5))
+            context.addLine(to: .init(x: 4.5, y: 2.5))
+            context.strokePath()
+
+            context.setStrokeColor(blue)
+            context.move   (to: .init(x: 3.5, y: 3.5))
+            context.addLine(to: .init(x: 2.5, y: 4.5))
+            context.strokePath()
+
+            context.setStrokeColor(black)
+            context.move   (to: .init(x: 1.5, y: 3.5))
+            context.addLine(to: .init(x: 0.5, y: 2.5))
+            context.strokePath()
+        }
+        
+        guard let pngData = nativeImage.pngData() else {
+            XCTFail("Not PNG data")
+            return
+        }
+        
+        guard let pngImage = PNG(data: pngData) else {
+            XCTFail("PNG data not PNG data?")
+            return
+        }
+        
+        XCTAssertEqual(pngImage.width, .init(intImageSize.width))
+        XCTAssertEqual(pngImage.height, .init(intImageSize.height))
+        
+        
+        func pixel(_ x: Int, _ y: Int) -> PNG.Pixel {
+            guard let pixel = pngImage.pixelAt(x: x, y: y) else {
+                XCTFail("No pixel at (\(x), \(y))")
+                fatalError()
+            }
+            
+            return pixel
+        }
+        
+        
+        func row(y: Int) -> [PNG.Pixel] {
+            (0..<intImageSize.width)
+                .map { pixel($0, y) }
+        }
+        
+        
+        func hexRow(y: Int) -> [UInt32] {
+            row(y: y).map(\.hexRRGGBB)
+        }
+        
+        
+        func hexes() -> [[UInt32]] {
+            (0..<intImageSize.height).map(hexRow)
+        }
+        
+        
+        let expectedHexes: [[UInt32]] = [
+            [0xFFFF00, 0xFFFF00, 0xFF0000, 0xFFFF00, 0xFFFF00],
+            [0xFFFF00, 0xFF0000, 0xFFFFFF, 0x00FF00, 0xFFFF00],
+            [0x000000, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0x00FF00],
+            [0xFFFF00, 0x000000, 0xFFFFFF, 0x0000FF, 0xFFFF00],
+            [0xFFFF00, 0xFFFF00, 0x0000FF, 0xFFFF00, 0xFFFF00],
+        ]
+        
+        
+        print("\n\nExpected:")
+        print(expectedHexes.hexStrings.map { $0.joined(separator: "  ") } .joined(separator: "\n\n"))
+        
+        
+        print("\n\nActual:")
+        print(hexes().hexStrings.map { $0.joined(separator: "  ") } .joined(separator: "\n\n"))
+        
+        
+        XCTAssertEqual(hexes().hexStrings, expectedHexes.hexStrings)
+    }
+    
+    
     static let allTests = [
         ("testDrawSwatch", testDrawSwatch),
         ("testDrawSwatchWithoutThisPackage", testDrawSwatchWithoutThisPackage),
+        ("testDrawDiamond", testDrawDiamond),
     ]
+}
+
+
+
+typealias PNG = Image<RGB<UInt8>>
+
+
+
+extension RGB where Channel == UInt8 {
+    /// The hex encoding of this pixel, as a `UInt32`, in the format `0xRRGGBB`
+    var hexRRGGBB: UInt32 {
+        UInt32()
+        | UInt32(red)   << (Channel.bitWidth * 2)
+        | UInt32(green) << (Channel.bitWidth * 1)
+        | UInt32(blue)//<< (Channel.bitWidth * 0)
+    }
+}
+
+
+
+extension Array where Element == [UInt32] {
+    var hexStrings: [[String]] {
+        map(\.hexStrings)
+    }
+}
+
+
+
+extension Array where Element == UInt32 {
+    var hexStrings: [String] {
+        map(\.hexString)
+    }
+}
+
+
+
+extension UInt32 {
+    var hexString: String {
+        let unpadded = String(self, radix: 0x10, uppercase: true)
+        return String(repeating: "0", count: Swift.max(0, 6 - unpadded.count))
+            + unpadded
+    }
 }
 
 


### PR DESCRIPTION
This requirement is mostly done to make sure that the ecosystem remains harmonious; you can always import the latest versions of all packages into your project.

This means we also require its platform versions and Swift tools version, bumping this repo to 2.0.0.

Took this Major version bump as an opportunity to both clean up the API a touch, and also resolve #4 